### PR TITLE
two missing options to make the apt config work

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Take this SSL-only app being served by [rainbows][2]:
 
 ```ruby
 :nginx => {
+  :distribution => 'precise',
+  :components => ['main'],
   :apps => {
     :myapp_ssl => {
       :listen      => [443],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,8 @@ require_recipe "apt"
 
 apt_repository "nginx" do
   uri "http://ppa.launchpad.net/nginx/stable/ubuntu"
+  distribution node[:nginx][:distribution]
+  components node[:nginx][:components]
   keyserver "keyserver.ubuntu.com"
   key "C300EE8C"
   action :add


### PR DESCRIPTION
on ubuntu precise at least
