### PR TITLE
Config files must exist before starting the service

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -18,10 +18,7 @@ remote_file "/usr/local/src/nginx-#{node[:nginx][:version]}.tar.gz" do
   action :create_if_missing
 end
 
-service "nginx" do
-  supports :start => true, :stop => true, :restart => true
-end
-
+service "nginx"
 bash "compile_nginx_source" do
   cwd "/usr/local/src"
   code <<-EOH
@@ -31,11 +28,6 @@ bash "compile_nginx_source" do
   EOH
   creates node[:nginx][:binary]
   notifies :restart, resources(:service => "nginx"), :delayed
-end
-
-service "nginx" do
-  supports :status => true, :restart => true, :reload => true
-  action :enable
 end
 
 directory node[:nginx][:log_dir] do
@@ -81,4 +73,9 @@ template "nginx.conf" do
   group "root"
   mode "0644"
   notifies :restart, resources(:service => "nginx"), :immediately
+end
+
+service "nginx" do
+  supports :status => true, :restart => true, :reload => true
+  action :enable
 end


### PR DESCRIPTION
Running "nginx::source" recipe resulted in error (running chef 10.12.0) because `/etc/init.d/nginx` haven't been created yet:

```
[Thu, 06 Sep 2012 05:43:58 -0400] INFO: Processing service[nginx] action enable (nginx::source line 36)
[Thu, 06 Sep 2012 05:43:58 -0400] ERROR: service[nginx] (nginx::source line 36) has had an error
[Thu, 06 Sep 2012 05:43:58 -0400] ERROR: service[nginx] (/var/chef/cookbooks/nginx/recipes/source.rb:36:in `from_file') had an error:
service[nginx] (nginx::source line 36) had an error: Errno::ENOENT: No such file or directory - /etc/init.d/nginx status
```

This pull request fixes this issue by creating configuration files first and then starting the service.
