### PR TITLE
Explicitly set large_client_header_buffers in nginx.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -187,6 +187,7 @@ default[:nginx][:types_hash_max_size]           = 2048
 default[:nginx][:server_tokens]                 = "off"
 default[:nginx][:server_names_hash_bucket_size] = 64
 default[:nginx][:server_name_in_redirect]       = "off"
+default[:nginx][:large_client_header_buffers]   = "4 8k"
 
 default[:nginx][:gzip]                          = "on"
 default[:nginx][:gzip_disable]                  = "msie6"

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -38,6 +38,8 @@ http {
   server_names_hash_bucket_size <%= node[:nginx][:server_names_hash_bucket_size] %>;
   server_name_in_redirect       <%= node[:nginx][:server_name_in_redirect] %>;
 
+  large_client_header_buffers  <%= node[:nginx][:large_client_header_buffers] %>;
+
   ##
   # Logging Settings
   ##


### PR DESCRIPTION
If you're on a version of nginx or an environment where large cookies are causing 400 errors, it's nice to be able to set large_client_header_buffers globally in nginx.conf, as per numerous posts such as:

http://orensol.com/2009/01/18/nginx-and-weird-400-bad-request-responses/

I put this in as we were switching over to Chef from manual configuration, and although I think the latest nginx now uses our "repaired" setting as the default, I still wanted to have it in there explicitly and also could be useful as cookies get bigger or for people not using latest version of nginx.
