### PR TITLE
Arrays are more appropriate

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -218,7 +218,7 @@ default[:nginx][:default_site] = true
 # Holds the entire vhost config
 # Check the apps recipe & the nginx_app provider
 #
-default[:nginx][:apps] = {}
+default[:nginx][:apps] = []
 
 # nginx status page (useful in conjunction with ganglia)
 #

--- a/recipes/apps.rb
+++ b/recipes/apps.rb
@@ -1,19 +1,19 @@
-node[:nginx][:apps].each do |app_name, app_attributes|
-  nginx_app app_name do
-    access_log            app_attributes[:access_log]
-    access_log_format     app_attributes[:access_log_format]
-    action                app_attributes[:action]
-    client_max_body_size  app_attributes[:client_max_body_size]
-    custom_directives     app_attributes[:custom_directives]
-    error_log             app_attributes[:error_log]
-    error_log_format      app_attributes[:error_log_format]
-    keepalive_timeout     app_attributes[:keepalive_timeout]
-    listen                app_attributes[:listen]
-    locations             app_attributes[:locations]
-    public_path           app_attributes[:public_path]
-    server_name           app_attributes[:server_name]
-    try_files             app_attributes[:try_files]
-    upstream_keepalive    app_attributes[:upstream_keepalive]
-    upstreams             app_attributes[:upstreams]
+node[:nginx][:apps].each do |app|
+  nginx_app app[:name] do
+    access_log            app[:access_log]
+    access_log_format     app[:access_log_format]
+    action                app[:action]
+    client_max_body_size  app[:client_max_body_size]
+    custom_directives     app[:custom_directives]
+    error_log             app[:error_log]
+    error_log_format      app[:error_log_format]
+    keepalive_timeout     app[:keepalive_timeout]
+    listen                app[:listen]
+    locations             app[:locations]
+    public_path           app[:public_path]
+    server_name           app[:server_name]
+    try_files             app[:try_files]
+    upstream_keepalive    app[:upstream_keepalive]
+    upstreams             app[:upstreams]
   end
 end


### PR DESCRIPTION
Why treat the name of the app any different?

``` ruby
configs[:nginx][:apps] = [app1, app2]
```

vs

``` ruby
configs[:nginx][:apps] = {
  :app1 => {...},
  :app2 => {...},
}
```

I am not 100% about this, leaving it here for now.
