### PR TITLE
define the keyserver as a default attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default[:nginx][:version]           = "1.4.4"
 default[:nginx][:version]           = "1.4.1" if node[:platform_version].to_f < 12.04
 default[:nginx][:apt_packages]      = %w[nginx-common nginx-full nginx]
+default[:nginx][:apt_keyserver]     = "keyserver.ubuntu.com"
 
 default[:nginx][:dir]               = "/etc/nginx"
 default[:nginx][:log_dir]           = "/var/log/nginx"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,7 +4,7 @@ apt_repository "nginx" do
   uri "http://ppa.launchpad.net/nginx/stable/ubuntu"
   distribution node[:nginx][:distribution]
   components node[:nginx][:components]
-  keyserver "keyserver.ubuntu.com:80"
+  keyserver "hkp://keyserver.ubuntu.com:80"
   key "C300EE8C"
   action :add
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,7 +4,7 @@ apt_repository "nginx" do
   uri "http://ppa.launchpad.net/nginx/stable/ubuntu"
   distribution node[:nginx][:distribution]
   components node[:nginx][:components]
-  keyserver "keyserver.ubuntu.com"
+  keyserver "keyserver.ubuntu.com:80"
   key "C300EE8C"
   action :add
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,7 +4,7 @@ apt_repository "nginx" do
   uri "http://ppa.launchpad.net/nginx/stable/ubuntu"
   distribution node[:nginx][:distribution]
   components node[:nginx][:components]
-  keyserver "hkp://keyserver.ubuntu.com:80"
+  keyserver node[:nginx][:apt_keyserver]
   key "C300EE8C"
   action :add
 end


### PR DESCRIPTION
define the keyserver url as a default attribute instead of a static value in the default recipe.  
This allows for an override attribute to workaround connecting to keyserver.ubuntu.com when behind firewalls that block port 11371 e.g. specifying:  
`hkp://keyserver.ubuntu.com:80`
