### PR TITLE
moving self signed certificates out of the ssl namespace.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -252,11 +252,11 @@ default[:nginx][:ssl][:prefer_server_ciphers] = "on"
 
 ### Self-Signed Certificate Configuration
 #
-default[:nginx][:ssl][:self_signed][:path] = false # ex: /etc/nginx/ssl
-default[:nginx][:ssl][:self_signed][:cert] = false # ex: foo.cert
-default[:nginx][:ssl][:self_signed][:key] = false # ex: foo.key
-default[:nginx][:ssl][:self_signed][:valid_days] = 15
-default[:nginx][:ssl][:self_signed][:subject] = {}
+default[:nginx][:ssl_self_signed][:path] = false # ex: /etc/nginx/ssl
+default[:nginx][:ssl_self_signed][:cert] = false # ex: foo.cert
+default[:nginx][:ssl_self_signed][:key] = false # ex: foo.key
+default[:nginx][:ssl_self_signed][:valid_days] = 15
+default[:nginx][:ssl_self_signed][:subject] = {}
 # subject is a Hash of any of the following values
 #  common_name: 'foo.example.com',
 #  country: 'US',

--- a/recipes/self_signed_cert.rb
+++ b/recipes/self_signed_cert.rb
@@ -1,9 +1,9 @@
-directory node[:nginx][:ssl][:self_signed][:path] do
+directory node[:nginx][:ssl_self_signed][:path] do
   action :create
 end
 
-node[:nginx][:ssl][:self_signed][:subject] = {}
-node[:nginx][:ssl][:self_signed][:valid_days]
+node[:nginx][:ssl_self_signed][:subject] = {}
+node[:nginx][:ssl_self_signed][:valid_days]
 
 ruby_block 'generate self-signed cert' do
   block do
@@ -29,7 +29,7 @@ ruby_block 'generate self-signed cert' do
       certificate.version = 2 # X509 v3
       certificate.serial = SecureRandom.random_number(32767)
       certificate.not_before = Time.now
-      certificate.not_after = certificate.not_before + (node[:nginx][:ssl][:self_signed][:valid_days] * 24*60*60)
+      certificate.not_after = certificate.not_before + (node[:nginx][:ssl_self_signed][:valid_days] * 24*60*60)
       certificate.public_key = key.public_key
       certificate.subject = OpenSSL::X509::Name.parse build_subject(subject)
       certificate.sign(key, OpenSSL::Digest::SHA256.new)
@@ -37,20 +37,20 @@ ruby_block 'generate self-signed cert' do
     end
 
     def write_certificate_and_key_to_disk(c, k)
-      ssl_path = node[:nginx][:ssl][:self_signed][:path]
-      ::File.open("#{ssl_path}/#{node[:nginx][:ssl][:self_signed][:cert]}") {|f|
+      ssl_path = node[:nginx][:ssl_self_signed][:path]
+      ::File.open("#{ssl_path}/#{node[:nginx][:ssl_self_signed][:cert]}") {|f|
         f.write c.to_pem # write cert to specified path and filename
       }
-      ::File.open("#{ssl_path}/#{node[:nginx][:ssl][:self_signed][:key]}" {|f|
+      ::File.open("#{ssl_path}/#{node[:nginx][:ssl_self_signed][:key]}" {|f|
         f.write k.to_pem # write private key to specified path and filename
       }
     end
 
-    cert, key = generate_self_signed_certificate_and_key(node[:nginx][:ssl][:self_signed][:subject])
+    cert, key = generate_self_signed_certificate_and_key(node[:nginx][:ssl_self_signed][:subject])
     write_certificate_and_key_to_disk(cert, key)
   end
   not_if do
-    (::File.exists?("#{node[:nginx][:ssl][:self_signed][:path]}/#{node[:nginx][:ssl][:self_signed][:cert]}") and
-     ::File.exists?("#{node[:nginx][:ssl][:self_signed][:path]}/#{node[:nginx][:ssl][:self_signed][:key]}"))
+    (::File.exists?("#{node[:nginx][:ssl_self_signed][:path]}/#{node[:nginx][:ssl_self_signed][:cert]}") and
+     ::File.exists?("#{node[:nginx][:ssl_self_signed][:path]}/#{node[:nginx][:ssl_self_signed][:key]}"))
   end
 end


### PR DESCRIPTION
This was breaking the ssl config because the empty hash for the self signed certs was getting dumping into
`/etc/nginx/conf.d/ssl.conf` and broke ssl configuration
